### PR TITLE
add tween.stop to finish dead tween

### DIFF
--- a/assets/cases/tween/scenes/tween-readonly.scene
+++ b/assets/cases/tween/scenes/tween-readonly.scene
@@ -100,6 +100,17 @@
     "_illuminanceHDR": 65000,
     "_illuminance": 65000,
     "_illuminanceLDR": 1.6927083333333335,
+    "_shadowEnabled": false,
+    "_shadowPcf": 0,
+    "_shadowBias": 0.00001,
+    "_shadowNormalBias": 0,
+    "_shadowSaturation": 0.75,
+    "_shadowDistance": 100,
+    "_shadowInvisibleOcclusionRange": 200,
+    "_shadowFixedArea": false,
+    "_shadowNear": 0.1,
+    "_shadowFar": 10,
+    "_shadowOrthoSize": 5,
     "_id": "597uMYCbhEtJQc0ffJlcgA"
   },
   {
@@ -320,7 +331,7 @@
     "_priority": 1073741824,
     "_fov": 45,
     "_fovAxis": 0,
-    "_orthoHeight": 361.2811387900356,
+    "_orthoHeight": 320,
     "_near": 1,
     "_far": 2000,
     "_color": {
@@ -686,7 +697,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": -200,
+      "x": -250,
       "y": 100,
       "z": 0
     },
@@ -723,7 +734,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 400,
+      "width": 500,
       "height": 100
     },
     "_anchorPoint": {
@@ -792,7 +803,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": 200,
+      "x": 250,
       "y": 100,
       "z": 0
     },
@@ -829,7 +840,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 400,
+      "width": 500,
       "height": 100
     },
     "_anchorPoint": {
@@ -1022,8 +1033,8 @@
   },
   {
     "__type__": "cc.ShadowsInfo",
-    "_type": 0,
     "_enabled": false,
+    "_type": 0,
     "_normal": {
       "__type__": "cc.Vec3",
       "x": 0,
@@ -1038,34 +1049,22 @@
       "b": 76,
       "a": 255
     },
-    "_firstSetCSM": false,
-    "_fixedArea": false,
-    "_pcf": 0,
-    "_bias": 0.00001,
-    "_normalBias": 0,
-    "_near": 0.1,
-    "_far": 10,
-    "_shadowDistance": 100,
-    "_invisibleOcclusionRange": 200,
-    "_orthoSize": 5,
     "_maxReceived": 4,
     "_size": {
       "__type__": "cc.Vec2",
       "x": 512,
       "y": 512
-    },
-    "_saturation": 0.75
+    }
   },
   {
     "__type__": "cc.SkyboxInfo",
-    "_applyDiffuseMap": false,
+    "_envLightingType": 0,
     "_envmapHDR": null,
     "_envmap": null,
     "_envmapLDR": null,
     "_diffuseMapHDR": null,
     "_diffuseMapLDR": null,
     "_enabled": false,
-    "_useIBL": false,
     "_useHDR": true
   },
   {

--- a/assets/cases/tween/script/TweenReadOnly.ts
+++ b/assets/cases/tween/script/TweenReadOnly.ts
@@ -1,5 +1,5 @@
 
-import { _decorator, Component, Node, Sprite, Vec3, tween } from 'cc';
+import { _decorator, Component, Node, Sprite, Vec3, tween, Tween } from 'cc';
 const { ccclass, property } = _decorator;
 
 /**
@@ -23,6 +23,8 @@ export class TweenReadOnly extends Component {
     // @property
     // serializableDummy = 0;
 
+    tweenRed: Tween<Node> = null!;
+    tweenGreen: Tween<Readonly<Vec3>> = null!;
 
     spriteRed: Sprite = null!;
     spriteGreen: Sprite = null!;
@@ -44,9 +46,18 @@ export class TweenReadOnly extends Component {
     //     // [4]
     // }
 
+    onDisable () {
+        this.tweenRed.stop();
+        this.tweenGreen.stop();
+    }
+
+    onDestroy () {
+        this.tweenRed.stop();
+        this.tweenGreen.stop();
+    }
 
     tweenStart() {
-        tween(this.spriteRed.node)
+        this.tweenRed = new Tween(this.spriteRed.node)
             .to(2,{position:new Vec3(this.oriRedPos.x,-200,0)})
             .call(()=> {
                 if(this.spriteRed && this.spriteRed.node) {
@@ -55,7 +66,8 @@ export class TweenReadOnly extends Component {
             .union()
             .repeatForever()
             .start();
-        tween(this.spriteGreen.node.position)
+
+        this.tweenGreen = new Tween(this.spriteGreen.node.position)
             .to(2,{y:-200})
             .call(()=>{
                 if(this.spriteGreen && this.spriteGreen.node) {
@@ -65,6 +77,8 @@ export class TweenReadOnly extends Component {
             .repeatForever()
             .start();
     }
+
+    
 }
 
 /**


### PR DESCRIPTION
在tween-readonly场景脚本中对两个tween动画添加了stop调用，避免场景切换或销毁后，动画还在执行而造成的各种异常。
https://github.com/cocos/3d-tasks/issues/11506
https://github.com/cocos/3d-tasks/issues/11510