### PR TITLE
remove the "ghost" animation clip with invalid uuid

### DIFF
--- a/assets/cases/setMipRange/setMipRange.scene
+++ b/assets/cases/setMipRange/setMipRange.scene
@@ -138,10 +138,6 @@
     "playOnLoad": true,
     "_clips": [
       {
-        "__uuid__": "82c68299-9c7b-4997-9ae0-3d295948e1fc",
-        "__expectedType__": "cc.AnimationClip"
-      },
-      {
         "__uuid__": "d50e748c-a52b-48c9-a1a2-3ad323379e5e",
         "__expectedType__": "cc.AnimationClip"
       }


### PR DESCRIPTION
The animation clip is deleted but its UUID still exists in the scene description file. 
I removed this clip from the description file in this PR.