### PR TITLE
fix cubemap effect's color blend, adjest the camera's animation.

### DIFF
--- a/assets/cases/setMipRange/setMipRange-camera.anim
+++ b/assets/cases/setMipRange/setMipRange-camera.anim
@@ -57,7 +57,7 @@
   {
     "__type__": "cc.RealCurve",
     "_times": [
-      0.01666666753590107,
+      0.016666666666666666,
       0.75,
       1.5,
       2.25,
@@ -137,7 +137,7 @@
   {
     "__type__": "cc.RealCurve",
     "_times": [
-      0.01666666753590107,
+      0.016666666666666666,
       0.75,
       1.5,
       2.25,
@@ -217,7 +217,7 @@
   {
     "__type__": "cc.RealCurve",
     "_times": [
-      0.01666666753590107,
+      0.016666666666666666,
       0.75,
       1.5,
       2.25,
@@ -228,31 +228,7 @@
         "__type__": "cc.RealKeyframeValue",
         "interpolationMode": 0,
         "tangentWeightMode": 0,
-        "value": 2,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      },
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 3,
-        "rightTangent": 0,
-        "rightTangentWeight": 1,
-        "leftTangent": 0,
-        "leftTangentWeight": 1,
-        "easingMethod": 0,
-        "__editorExtras__": {}
-      },
-      {
-        "__type__": "cc.RealKeyframeValue",
-        "interpolationMode": 0,
-        "tangentWeightMode": 0,
-        "value": 12,
+        "value": 15,
         "rightTangent": 0,
         "rightTangentWeight": 1,
         "leftTangent": 0,
@@ -277,6 +253,30 @@
         "interpolationMode": 0,
         "tangentWeightMode": 0,
         "value": 2,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {}
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 3,
+        "rightTangent": 0,
+        "rightTangentWeight": 1,
+        "leftTangent": 0,
+        "leftTangentWeight": 1,
+        "easingMethod": 0,
+        "__editorExtras__": {}
+      },
+      {
+        "__type__": "cc.RealKeyframeValue",
+        "interpolationMode": 0,
+        "tangentWeightMode": 0,
+        "value": 15,
         "rightTangent": 0,
         "rightTangentWeight": 1,
         "leftTangent": 0,

--- a/assets/cases/setMipRange/setMipRange-cube.mtl
+++ b/assets/cases/setMipRange/setMipRange-cube.mtl
@@ -23,11 +23,6 @@
     }
   ],
   "_props": [
-    {
-      "mainTexture": {
-        "__uuid__": "2d100bb6-dbf1-42c4-9fd0-a518b4911f5f@b47c0",
-        "__expectedType__": "cc.TextureCube"
-      }
-    }
+    {}
   ]
 }

--- a/assets/cases/setMipRange/setMipRange-cube.ts
+++ b/assets/cases/setMipRange/setMipRange-cube.ts
@@ -54,16 +54,18 @@ export class setMipRange_cubemap extends Component {
 
         this.cubeTexture.mipmaps = images;
         this.cubeTexture.setMipFilter(2);
+        this.cubeTexture!.setMipRange(0, mipCount);
+        this.cubeMat!.setProperty('cubeMap', this.cubeTexture);
 
         this.schedule(() => {
             this.cubeTexture!.setMipRange(0, mipCount);
             this.cubeMat!.setProperty('cubeMap', this.cubeTexture);
-        }, 6, macro.REPEAT_FOREVER, 1.5);
+        }, 6, macro.REPEAT_FOREVER, 0);
 
         this.schedule(() => {
             this.cubeTexture!.setMipRange(1, mipCount);
             this.cubeMat!.setProperty('cubeMap', this.cubeTexture);
-        }, 6, macro.REPEAT_FOREVER, 4.5);
+        }, 6, macro.REPEAT_FOREVER, 3);
         this.ready = true;
     }
 }

--- a/assets/cases/setMipRange/setMipRange-cubemap.effect
+++ b/assets/cases/setMipRange/setMipRange-cubemap.effect
@@ -44,11 +44,9 @@ CCProgram complex-fs %{
   uniform samplerCube cubeMap;
 
   vec4 frag () {
-    #if USE_RGBE_CUBEMAP
-      vec3 c = unpackRGBE(texture(cubeMap, viewDir.xyz));
-    #else
-      vec3 c = SRGBToLinear(texture(cubeMap, viewDir.xyz).rgb);
-    #endif
-    return CCFragOutput(vec4(c * cc_ambientSky.w, 1.0));
+    vec4 color = texture(cubeMap, viewDir.xyz);
+    if(color.a < 1.0)
+      color = vec4(mix(vec3(0.0), color.rgb, color.a), 1.0);
+    return color;
   }
 }%

--- a/assets/cases/setMipRange/setMipRange-quad.ts
+++ b/assets/cases/setMipRange/setMipRange-quad.ts
@@ -23,16 +23,18 @@ export class setMipRange_quad extends Component {
 
         this.textureUsed.mipmaps = this.mipMaps;
         this.textureUsed.setMipFilter(2);
+        this.textureUsed!.setMipRange(0, this.mipMaps.length);
+        this.mat!.setProperty('albedoMap', this.textureUsed);
 
         this.schedule(() => {
             this.textureUsed!.setMipRange(0, this.mipMaps.length);
             this.mat!.setProperty('albedoMap', this.textureUsed);
-        }, 6, macro.REPEAT_FOREVER, 1.5);
+        }, 6, macro.REPEAT_FOREVER, 0);
 
         this.schedule(() => {
             this.textureUsed!.setMipRange(1, this.mipMaps.length);
             this.mat!.setProperty('albedoMap', this.textureUsed);
-        }, 6, macro.REPEAT_FOREVER, 4.5);
+        }, 6, macro.REPEAT_FOREVER, 3);
 
         this.ready = true;
     }

--- a/assets/cases/setMipRange/setMipRange.scene
+++ b/assets/cases/setMipRange/setMipRange.scene
@@ -61,7 +61,7 @@
       "__type__": "cc.Vec3",
       "x": 0.75,
       "y": 0,
-      "z": 2
+      "z": 15
     },
     "_lrot": {
       "__type__": "cc.Quat",
@@ -553,7 +553,7 @@
       "b": 255,
       "a": 255
     },
-    "_string": "\n\n\n\n\n\n\n\n\n\nThe camera will move backwards and forwards repetitively.\nIn odd loops, mip0 is a treasure box.\nIn even loops, mip0 is a golden coin.\nNot supported by WebGL1 and GLES2",
+    "_string": "\n\n\n\n\n\n\n\n\n\nThe camera will move forwards and backwards repetitively.\nIn odd loops, mip0 is a treasure box.\nIn even loops, mip0 is a golden coin.\nNot supported by WebGL1 and GLES2",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
     "_actualFontSize": 20,

--- a/assets/cases/setMipRange/setMipRange.scene.meta
+++ b/assets/cases/setMipRange/setMipRange.scene.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.1.37",
+  "ver": "1.1.38",
   "importer": "scene",
   "imported": true,
   "uuid": "3574a9aa-7a6d-4cf2-a67c-ed3a83317d17",


### PR DESCRIPTION
fix cubemap effect's color blend, adjest the camera's animation.

Re: https://github.com/cocos/3d-tasks/issues/11775#issue-1184466779

Now, setMipRange looks like that:

Near the camera: 
1. odd
![box](https://user-images.githubusercontent.com/24495793/160603701-e83ab59b-ace6-4d20-a703-376771381649.png)

2. even
![goldcoin](https://user-images.githubusercontent.com/24495793/160603721-464e1d9e-cad8-461a-a069-10adbeb22c61.png)

Far away from the camera:
![far](https://user-images.githubusercontent.com/24495793/160603748-252ba7cd-6001-4f01-b4a2-a2532f779e5f.png)

**Note:** On WebGL1 and GLES2, the mipmap should always be a coin when close to the scene.