### PR TITLE
fix : gamepad controller the direction is reversed

### DIFF
--- a/assets/cases/TestList/backbutton.ts
+++ b/assets/cases/TestList/backbutton.ts
@@ -260,8 +260,8 @@ export class BackButton extends Component {
         const gp = event.gamepad;
         const ls = gp.leftStick.getValue();
 
-        const isLeft = this.isControllerButtonPress(gp.dpad.left.getValue()) || ls.x > axisPrecision;
-        const isRight = this.isControllerButtonPress(gp.dpad.right.getValue()) || (ls.x < -axisPrecision);
+        const isLeft = this.isControllerButtonPress(gp.dpad.left.getValue()) || ls.x < -axisPrecision;
+        const isRight = this.isControllerButtonPress(gp.dpad.right.getValue()) || (ls.x > axisPrecision);
         const isBack = this.isControllerButtonPress(gp.buttonEast.getValue());
         if (isBack) {
             this.backToList();


### PR DESCRIPTION
fix https://github.com/cocos/3d-tasks/issues/12618 ： 左上方的圆形按钮向左摇杆切换下一项，方向错误