### PR TITLE
Fix circular reference in backbutton.ts

### DIFF
--- a/assets/cases/TestList/backbutton.ts
+++ b/assets/cases/TestList/backbutton.ts
@@ -1,6 +1,6 @@
 import { EventGamepad, input, Input, _decorator, Component, Node, ScrollView, Vec3, game, Label, director, Director, assetManager, find, Canvas, Layers, JsonAsset, profiler, sys } from "cc";
 const { ccclass, property } = _decorator;
-import { SceneList } from "./scenelist";
+import { SceneList } from "./common";
 import { StateCode, TestFramework } from "./TestFramework";
 
 declare class AutoTestConfigJson extends JsonAsset {

--- a/assets/cases/TestList/common.ts
+++ b/assets/cases/TestList/common.ts
@@ -1,0 +1,7 @@
+export class SceneList {
+
+    static sceneArray: string[] = [];
+    static sceneFold: string[] = [];
+    static foldCount: number = 0;
+
+}

--- a/assets/cases/TestList/folditem.ts
+++ b/assets/cases/TestList/folditem.ts
@@ -1,5 +1,6 @@
 import { _decorator, Component, Node, Label, director } from "cc";
-import { SceneList, SceneManager } from "./scenelist";
+import { SceneManager } from "./scenelist";
+import { SceneList } from "./common";
 import { BackButton } from "./backbutton";
 const { ccclass, property } = _decorator;
 

--- a/assets/cases/TestList/scenelist.ts
+++ b/assets/cases/TestList/scenelist.ts
@@ -2,14 +2,7 @@ import { Sprite, Button, input, Input, Vec2, _decorator, Component, Node, Scroll
 import { ItemType, ListItem } from "./listitem";
 const { ccclass, property } = _decorator;
 import { BackButton } from "./backbutton";
-
-export class SceneList {
-
-    static sceneArray: string[] = [];
-    static sceneFold: string[] = [];
-    static foldCount: number = 0;
-
-}
+import { SceneList } from "./common";
 
 class DisplayItems {
     index: number = -1;


### PR DESCRIPTION
‘scenelist.ts‘ should be named ‘sceneManager.ts’
‘common.ts‘ should be named ‘scenelist.ts’, but there are more changes in this way, and it is not sure that it will cause other problems. Fixing in next version