### PR TITLE
add back physics-2d module

### DIFF
--- a/settings/v2/packages/engine.json
+++ b/settings/v2/packages/engine.json
@@ -51,7 +51,7 @@
         "_value": true
       },
       "physics-2d": {
-        "_value": false,
+        "_value": true,
         "_option": "physics-2d-builtin"
       },
       "physics-2d-box2d": {
@@ -138,6 +138,7 @@
       "light-probe",
       "particle",
       "particle-2d",
+      "physics-2d-builtin",
       "physics-cannon",
       "primitive",
       "profiler",


### PR DESCRIPTION
https://github.com/cocos/3d-tasks/issues/16867

this module is dependent on by SpineColiider test case, so I add it back

this would inscreese 0.04mb size code into the release version of cc.js