### PR TITLE
[HACK] don't test subpackage on ByteDance platform

### DIFF
--- a/settings/v2/packages/builder.json
+++ b/settings/v2/packages/builder.json
@@ -607,8 +607,8 @@
                 "isRemote": false
               },
               "bytedance-mini-game": {
-                "compressionType": "subpackage",
-                "isRemote": false
+                "compressionType": "merge_dep",
+                "isRemote": true
               },
               "oppo-mini-game": {
                 "compressionType": "subpackage",


### PR DESCRIPTION
https://github.com/cocos/3d-tasks/issues/16867

the subpackage mechanism will trigger the strict code size detection of Byte DevTools, making it impossible to preview the project on the mobile device