### PR TITLE
Skip `lod.scene` on XiaoMi-Quick-App

### DIFF
--- a/assets/cases/TestList/backbutton.ts
+++ b/assets/cases/TestList/backbutton.ts
@@ -68,6 +68,7 @@ export class BackButton extends Component {
                 }
             }
 
+            // The size of the resource file is exceedingly large, and it may reach the memory threshold on this platform.
             if (sys.platform === sys.Platform.XIAOMI_QUICK_GAME && str.endsWith('lod.scene')) {
                 continue;
             }

--- a/assets/cases/TestList/backbutton.ts
+++ b/assets/cases/TestList/backbutton.ts
@@ -67,6 +67,11 @@ export class BackButton extends Component {
                     continue;
                 }
             }
+
+            if (sys.platform === sys.Platform.XIAOMI_QUICK_GAME && str.endsWith('lod.scene')) {
+                continue;
+            }
+
             const firstIndex = str.lastIndexOf('/') + 1;
             const lastIndex = str.lastIndexOf('.scene');
             let currentScene = str.substring(firstIndex, lastIndex);


### PR DESCRIPTION
Ref: https://github.com/cocos/3d-tasks/issues/16938

The size of the resource file is exceedingly large, and it may reach the memory threshold on this platform.
Obscure the scene Level of Detail (LOD) on the Xiaomi Quick App platform.