### PR TITLE
fix mask-type-change srceenshot error

### DIFF
--- a/assets/auto-test-case/staticScene/mask-type-change.test.ts
+++ b/assets/auto-test-case/staticScene/mask-type-change.test.ts
@@ -7,7 +7,7 @@ import { find } from 'cc';
 @testClass('MaskTypeChange')
 export class MaskTypeChange{
     _delay = 1;
-    _dt =120;
+    _dt =122;
     
     @testCase
     async start(){


### PR DESCRIPTION
Modify the frame rate to wait for when taking a mask type change screenshot, otherwise the captured image does not include each type of change