### PR TITLE
Fix an error log if the platform doesn't support to decode audio file to PCM audio buffer.

### DIFF
--- a/assets/cases/audio/audioBuffer.ts
+++ b/assets/cases/audio/audioBuffer.ts
@@ -104,6 +104,9 @@ export class audioBuffer extends Component {
     }
 
     update (dt: number) {
+        if (this.noSupported.active) {
+            return;
+        }
         if (this.slider.progress === this._currentProgress) {
             return;
         }


### PR DESCRIPTION
The error log is :

TypeError: Cannot set property 'width' of null
| at audioBuffer.update (usr_main.js:2350:32)
| at eval (src/cocos-js/cc.js:44593:29)