### PR TITLE
Update LoadRes.test.ts screenshot time

### DIFF
--- a/assets/auto-test-case/dynamic/scripting/LoadRes.test.ts
+++ b/assets/auto-test-case/dynamic/scripting/LoadRes.test.ts
@@ -27,7 +27,7 @@ export class LoadRes {
         // @ts-ignore
         find('Canvas').getComponent('LoadResExample').loadSpriteFrame();
         await sleep(3)
-        await screenshot_custom(this._dt);
+        await screenshot_custom(this._dt * 100);
     }
 
 

--- a/assets/auto-test-config.json
+++ b/assets/auto-test-config.json
@@ -212,6 +212,7 @@
         "hdr-ldr",
         "tween-readonly",
         "bmfont-wrap",
-        "rich-text-font-color"
+        "rich-text-font-color",
+        "skew"
     ]
 }

--- a/assets/auto-test-config.json
+++ b/assets/auto-test-config.json
@@ -213,6 +213,7 @@
         "tween-readonly",
         "bmfont-wrap",
         "rich-text-font-color",
-        "skew"
+        "skew",
+        "director-after-draw-test"
     ]
 }


### PR DESCRIPTION
Screenshot taken when LoadRes is not fully loaded, resulting in image comparison failure. Delay now to avoid this situation