### PR TITLE
Modify uiopacity test case layout

### DIFF
--- a/assets/cases/ui/other/opacity/ui-opacity-change-parent.scene
+++ b/assets/cases/ui/other/opacity/ui-opacity-change-parent.scene
@@ -394,7 +394,7 @@
     "_string": "UiOpacity changes parent",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
-    "_actualFontSize": 40,
+    "_actualFontSize": 48,
     "_fontSize": 40,
     "_fontFamily": "Arial",
     "_lineHeight": 50,
@@ -1394,7 +1394,7 @@
     "_string": "prev",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -1708,7 +1708,7 @@
     "_priority": 1073741824,
     "_fov": 45,
     "_fovAxis": 0,
-    "_orthoHeight": 452,
+    "_orthoHeight": 340,
     "_near": 1,
     "_far": 2000,
     "_color": {
@@ -2001,7 +2001,7 @@
     "_string": "next",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -2134,7 +2134,7 @@
     "_string": "label",
     "_horizontalAlign": 0,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -2194,7 +2194,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": 96,
+      "x": 57,
       "y": 196.978,
       "z": 0
     },
@@ -2233,7 +2233,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 700,
+      "width": 780,
       "height": 50.4
     },
     "_anchorPoint": {
@@ -2266,7 +2266,7 @@
     "_string": "label",
     "_horizontalAlign": 0,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -2326,7 +2326,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": 96,
+      "x": 57,
       "y": 145.338,
       "z": 0
     },
@@ -2365,7 +2365,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 700,
+      "width": 780,
       "height": 50.4
     },
     "_anchorPoint": {
@@ -2398,7 +2398,7 @@
     "_string": "label",
     "_horizontalAlign": 0,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -2458,7 +2458,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": 96,
+      "x": 57,
       "y": 104.893,
       "z": 0
     },
@@ -2497,7 +2497,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 700,
+      "width": 780,
       "height": 50.4
     },
     "_anchorPoint": {
@@ -2655,7 +2655,7 @@
     "_string": "reset",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -2981,7 +2981,7 @@
     "_string": "separate",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -3307,7 +3307,7 @@
     "_string": "disable",
     "_horizontalAlign": 1,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -3506,7 +3506,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": -349.594,
+      "x": -404.594,
       "y": 194.72,
       "z": 0
     },
@@ -3545,7 +3545,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 180,
+      "width": 130,
       "height": 50.4
     },
     "_anchorPoint": {
@@ -3578,7 +3578,7 @@
     "_string": "formulas = ",
     "_horizontalAlign": 2,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -3638,7 +3638,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": -349.594,
+      "x": -404.594,
       "y": 147.313,
       "z": 0
     },
@@ -3677,7 +3677,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 180,
+      "width": 130,
       "height": 50.4
     },
     "_anchorPoint": {
@@ -3710,7 +3710,7 @@
     "_string": "         = ",
     "_horizontalAlign": 2,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,
@@ -3770,7 +3770,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": -349.594,
+      "x": -404.594,
       "y": 104.421,
       "z": 0
     },
@@ -3809,7 +3809,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 180,
+      "width": 130,
       "height": 50.4
     },
     "_anchorPoint": {
@@ -3842,7 +3842,7 @@
     "_string": "result  = ",
     "_horizontalAlign": 2,
     "_verticalAlign": 1,
-    "_actualFontSize": 20,
+    "_actualFontSize": 24,
     "_fontSize": 20,
     "_fontFamily": "Arial",
     "_lineHeight": 40,


### PR DESCRIPTION
The test case of ui-opacity-change-parent has an abnormal layout on some phones, which should be a problem with the applet, as it is only a problem with some platforms, and it is suspected that the font size is not the same as the preset, which leads to a different layout.

![企业微信截图_17452923059501](https://github.com/user-attachments/assets/d70d2fef-7631-4b3b-ac76-0d158a4dd551)
vivo, oppo, huawei, weibo will be available mainly on iqoo (android11) phones
